### PR TITLE
sdp-tech#293 feat : sitemap and robots.txt update

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,9 +1,5 @@
-# https://www.robotstxt.org/robotstxt.html
-User-agent: Googlebot
-User-agent: Yeti
+User-agent:*
 Disallow: /mypage
 Disallow: /mypick
 Disallow: /auth
-
-
 Sitemap: https://www.sasm.co.kr/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -4,5 +4,6 @@
 <url> <loc>https://www.sasm.co.kr/</loc> </url>
 <url> <loc>https://www.sasm.co.kr/map</loc> </url>
 <url> <loc>https://www.sasm.co.kr/story</loc> </url>
+<url> <loc>https://www.sasm.co.kr/curation</loc> </url>
 <url> <loc>https://www.sasm.co.kr/</loc> </url>
 </urlset>


### PR DESCRIPTION
1. 구글, 네이버만 시범 운영하던 것을 모든 웹사이트에서 크롤링하도록 변경
2. 사이트맵에 curation 페이지 추가