### PR TITLE
sdp-tech#476 fix : map like

### DIFF
--- a/src/components/SpotMap/SpotDetail/DetailCard.jsx
+++ b/src/components/SpotMap/SpotDetail/DetailCard.jsx
@@ -179,7 +179,7 @@ export default function DetailCard({ detailData, modalClose, like, setLike }) {
     } else {
       const response = await request.post("/places/place_like/", { id: detailData.id }, null);
       //색상 채우기
-      setLike(!like);
+      like ? setLike(false) : setLike(true);
     }
   };
   const handleTab = (event, value) => {
@@ -211,14 +211,14 @@ export default function DetailCard({ detailData, modalClose, like, setLike }) {
             ) : (
               ""
             )}
-            
+            {like === undefined ? <></> :
             <LikeButton>
               {detailData.user_liked ? (
-                <HeartButton like={like} onClick={toggleLike} />
-              ) : (
                 <HeartButton like={!like} onClick={toggleLike} />
+              ) : (
+                <HeartButton like={like} onClick={toggleLike} />
               )}
-            </LikeButton>
+            </LikeButton>}
           </ButtonBox>
         </InfoBox>
         <Tabs value={value} onChange={handleTab}>

--- a/src/components/SpotMap/SpotList/ItemCard.jsx
+++ b/src/components/SpotMap/SpotList/ItemCard.jsx
@@ -140,7 +140,7 @@ export default function ItemCard({ placeData, categoryNum, setTemp }) {
     else {
       const response = await request.post("/places/place_like/", { id: placeData.id });
       //색상 채우기
-      setLike(!like);
+      like ? setLike(false) : setLike(true);
     }
   };
   // 마커 전부 초기화


### PR DESCRIPTION
1. spotlist와 detailcard에서 좋아요 동시반영 수정
2. 다른 페이지(story, mypick, mypage 등)에서 들어와 detailcard가 열리는 경우, props가 전달되지 않아서 setLike가 undefined 되는 현상 발생. => like가 undefined면 보이지 않게 처리