### PR TITLE
sdp-tech#476 fix : map categoty font size

### DIFF
--- a/src/components/SpotMap/Map.jsx
+++ b/src/components/SpotMap/Map.jsx
@@ -179,7 +179,7 @@ const Markers = ({ navermaps, left, right, title, id, category, categoryNum, set
         </div>
         <div>
           <p style="margin: 0; font-size: 0.9rem; font-weight: bold; position: absolute; left: 45px;">${title.length > 11 ? title.slice(0,10) + '...': title}</p>
-          <p style="margin: 0; font-size: 0.5rem; position: absolute; left: 45px; bottom: 5px;">${category}</p>
+          <p style="margin: 0; font-size: 0.6rem; position: absolute; left: 45px; bottom: 5px;">${category}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
지도 클러스터링 하다가 패키지 업데이트 중 모듈 에러 나서 우선 폰트 사이즈만 고침