### PR TITLE
sdp-tech#476 fix : fix go to map

### DIFF
--- a/src/components/Curation/components/CurationDetailBox.jsx
+++ b/src/components/Curation/components/CurationDetailBox.jsx
@@ -444,7 +444,10 @@ export const Storys = ({
               </Button> : <></>
             }
         <ButtonWrapper>
-          <GotoMap onClick={() => { navigate(`/map?page=1&place=${place_name}`, {state: {name: place_name}})}}>
+          <GotoMap onClick={() => { 
+            navigate(`/map?page=1&place=${place_name}`, {state: {name: place_name}});
+            localStorage.setItem("place_name", place_name);
+            }}>
             <Text>위치 확인하기</Text>
           </GotoMap>
           <GotoStory onClick={() => { navigate(`/story/${story_id}`)}}>

--- a/src/components/SpotMap/Map.jsx
+++ b/src/components/SpotMap/Map.jsx
@@ -205,14 +205,11 @@ const Markers = ({ navermaps, left, right, title, id, category, categoryNum, set
       MarkerChange();
       setModalOpen(true);
     }
-    const stateName = location.state?.name;
     const localStorageName = localStorage.getItem("place_name");
-
-    if (stateName || localStorageName) {
+    
+    if (localStorageName) {
       openModal();
-      if (localStorageName) {
-        localStorage.removeItem("place_name");
-      }
+      localStorage.removeItem("place_name");
     }
   } ,[]);
 

--- a/src/components/Story/components/StoryDetailBox.jsx
+++ b/src/components/Story/components/StoryDetailBox.jsx
@@ -315,7 +315,8 @@ const StoryDetailBox = (props) => {
   const navigate = useNavigate();
   const request = Request(navigate);
   const handlePageGoToMap = (place_name) => {
-    navigate(`/map?page=1&place=${place_name}`, { state: { name : place_name }})
+    navigate(`/map?page=1&place=${place_name}`, { state: { name : place_name }});
+    localStorage.setItem('place_name', place_name);
   };
   const [refresh, setRefresh] = useState(false);
   const myEmail = localStorage.getItem('email');

--- a/src/components/mypick/myplace/ItemCard.jsx
+++ b/src/components/mypick/myplace/ItemCard.jsx
@@ -101,7 +101,7 @@ export default function ItemCard(props) {
           }}
         >
             <PlacenameBox>
-              <Placename to={`/map?page=1&place=${place_name}`} state={{name : place_name}} style={{ textDecoration: 'none' }}>
+              <Placename to={`/map?page=1&place=${place_name}`} state={{name : place_name}} onClick={()=>{localStorage.setItem("place_name", place_name)}} style={{ textDecoration: 'none' }}>
                 {props.place_name}
               </Placename>
               <div style={{ display: 'flex', }}>


### PR DESCRIPTION
1. 리액트 버전 업데이트에 따라 기능이 수정된 것으로 보임.(ex.버그 수정) 이로 인해 map 페이지가 렌더링 될 때 location.state가 사라지는 현상 발생. (맵이 여러 번 렌더링 되기 때문인 것 같음)
2. location.state를 이용해 gotomap을 이용하던 게 현시점에서 불가능해 우선 localStorage을 이용해 작동.
3. 리팩토링 등의 과정을 거쳐 최적화 이후 state값을 이용하는 등의 방법을 찾아야 할 것으로 보임
4. queryparameter 적용을 위해 state값을 남겨둠