### PR TITLE
sdp-tech#476 fix : pagination division

### DIFF
--- a/src/components/common/Pagination.jsx
+++ b/src/components/common/Pagination.jsx
@@ -2,36 +2,57 @@ import React from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { useLocation } from "react-router-dom";
-import qs from 'qs';
+import qs from "qs";
 
 function Pagination({ total, limit }) {
-  const numPages = Math.ceil(total / limit);
   const location = useLocation();
   const queryString = qs.parse(location.search, {
     ignoreQueryPrefix: true
   });
-  const previousPage = (parseInt(queryString.page) -1);
-  const nextPage = (parseInt(queryString.page) +1);
+  const currentPage = parseInt(queryString.page) || 1;
+  const numPages = Math.ceil(total / limit);
+  const pagesToShow = 10; // 페이지 최대 개수
+
+  // 현재 페이지에서 시작과 끝 페이지 계산
+  let startPage = Math.max(currentPage - Math.floor(pagesToShow / 2), 1);
+  let endPage = Math.min(startPage + pagesToShow - 1, numPages);
+
+  if (endPage - startPage + 1 < pagesToShow) {
+    // 마지막 부분에 다가갈 때, 첫 페이지 조정
+    startPage = Math.max(endPage - pagesToShow + 1, 1);
+  }
+
+  const previousPage = currentPage > 1 ? currentPage - 1 : 1;
+  const nextPage = currentPage < numPages ? currentPage + 1 : numPages;
 
   return (
     <>
-      {total == 0 ? (
+      {total === 0 ? (
         ""
       ) : (
         <Nav>
-          <StyledLink to={`?page=${previousPage}`} style={previousPage === 0? {display: 'none'} : {display:'inline'}}>
+          <StyledLink
+            to={`?page=${previousPage}`}
+            style={previousPage === 1 ? { display: "none" } : { display: "inline" }}
+          >
             &lt;
           </StyledLink>
-          {Array(numPages)
-            .fill()
-            .map((_, i) => (
-              <StyledLink to={`?page=${i+1}`}
-              aria-current={parseInt(queryString.page) === i + 1 ? "page" : null}
+          {Array.from({ length: endPage - startPage + 1 }, (_, i) => {
+            const page = i + startPage;
+            return (
+              <StyledLink
+                key={page}
+                to={`?page=${page}`}
+                aria-current={currentPage === page ? "page" : null}
               >
-                {i + 1}
+                {page}
               </StyledLink>
-            ))}
-          <StyledLink to={`?page=${nextPage}`} style={nextPage === numPages+1? {display: 'none'} : {display:'inline'}}>
+            );
+          })}
+          <StyledLink
+            to={`?page=${nextPage}`}
+            style={nextPage === numPages ? { display: "none" } : { display: "inline" }}
+          >
             &gt;
           </StyledLink>
         </Nav>
@@ -46,7 +67,7 @@ const Nav = styled.nav`
   align-items: center;
   font-family: pretendard;
 `;
- const StyledLink = styled(Link)`
+const StyledLink = styled(Link)`
   border: none;
   border-radius: 8px;
   padding: 8px;


### PR DESCRIPTION
페이지 개수가 11페이지 이상일 때, 1부터 11까지 쭉 다 보이는 현상 발생. 현재 최대 10개로 제한해 11페이지로 넘어갈 시 2,3,4...9,10,11로 보이게 끔 수정